### PR TITLE
Fixed the issue with filtering the array + fixed tasks with wrong fie…

### DIFF
--- a/utils/statisticHandler.ts
+++ b/utils/statisticHandler.ts
@@ -48,15 +48,12 @@ export function sortTasksFromCompletions(
   tasks: Task[],
 ) {
   sortedTasks = [];
-  completions.forEach((completion) => {
-    tasks.forEach((task) => {
-      if (completion.taskId === task.id) {
-        if (!sortedTasks.includes(task)) {
-          sortedTasks.push(task);
-        }
-      }
-    });
-  });
+
+  const taskWithCompletions = new Set(
+    completions.map((completion) => completion.taskId),
+  );
+  console.log("task with completions: ", taskWithCompletions);
+  sortedTasks = tasks.filter((task) => taskWithCompletions.has(task.id));
 
   console.log("SortedtTasks: ", sortedTasks);
   console.log(sortedTasks.length);


### PR DESCRIPTION
…lds in database

Now the tasks is filtered IF the id is current in any of the sorted taskCompletions:

Tasks in the household at the moment: 16
Tasks with taskCompletions shown in the stat...Screen: 8

![image](https://github.com/Radagastno1/Household/assets/112871777/aaa2f917-b435-49c9-82be-a0dbf34a1229)

Doublechecked with firestore and its correct :)
