### PR TITLE
255 moving edit function to household screen and avatar only shows when is owner

### DIFF
--- a/screens/HouseholdAccountScreen.tsx
+++ b/screens/HouseholdAccountScreen.tsx
@@ -54,18 +54,8 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
     activeProfile?.profileName,
   );
 
-  const handleSaveClick = () => {
-    if (activeProfile) {
-      dispatch(
-        editProfileName({
-          profileId: activeProfile?.id,
-          newProfileName: updatedProfileName ?? activeProfile.profileName,
-        }),
-      );
-      setIsEditing(false);
-      console.log("NYA PROFILNAMNET", { updatedProfileName });
-    }
-  };
+  const [editingStates, setEditingStates] = useState(Array(households?.length).fill(false));
+
 
   const handleHouseholdSaveClick = async (editHouseholdId: string) => {
     if (editHouseholdId) {
@@ -75,13 +65,15 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
           newHouseholdName: updatedHouseholdName ?? editHouseholdId,
         }),
       );
-      setIsEditing(false);
-      console.log("NYA PROFILNAMNET", { updatedHouseholdName });
+         // Update the editing state for the edited household
+         setEditingStates(Array(households?.length).fill(false));
+
     }
   };
-  const cancelEditing = (household: Household) => {
-    setIsEditing(false);
-    setUpdatedHouseholdname(household.name); // Reset the edited name to the original name
+  const cancelEditing = (index:number) => {
+    const updatedEditingStates = [...editingStates];
+    updatedEditingStates[index] = false;
+    setEditingStates(updatedEditingStates); // Reset the edited name to the original name
   };
 
   //-----------------------------------------------------------------------------------
@@ -107,7 +99,7 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
     };
 
     fetchData();
-  }, []); //runs only onece
+  }, [editingStates]); //runs only onece
 
   async function GetHouseholdIdsFromActiveUser() {
     const householdsId: string[] = [];
@@ -210,7 +202,7 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
   });
 
 
-  const [editingStates, setEditingStates] = useState(Array(households?.length).fill(false));
+ 
 
   return (
     <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
@@ -249,7 +241,9 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
                 { flexDirection: "row", justifyContent: "space-between" },
               ]}
               onPress={() => {
-                handleEnterHousehold(household);
+                if (!editingStates[index]) {
+                    handleEnterHousehold(household);
+                  }
               }}
             >
                <View style={{ flexDirection: "row", alignItems: "center" }}>
@@ -314,7 +308,7 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
                 <View>
                   <Button
                     mode="elevated"
-                    onPress={() => cancelEditing(household)}
+                    onPress={() => cancelEditing(index)}
                   >
                     Avbryt
                   </Button>

--- a/screens/HouseholdAccountScreen.tsx
+++ b/screens/HouseholdAccountScreen.tsx
@@ -1,4 +1,4 @@
-import { MaterialIcons } from "@expo/vector-icons";
+
 import React, { useEffect, useRef, useState } from "react";
 import {
   Animated,
@@ -26,7 +26,6 @@ import {
   sethouseholdActive,
 } from "../store/household/householdSlice";
 import {
-  editProfileName,
   fetchAllProfilesByHousehold,
   setProfileByHouseholdAndUser,
 } from "../store/profile/profileSlice";
@@ -41,21 +40,18 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
   const [profiles, setProfiles] = useState<(Profile[] | undefined)[]>([]);
   console.log("Nu är användaren ", activeUser, "inloggad");
 
-  //------------------------------------------------------------------------------
-  const activeProfiles = useAppSelector((state) => state.profile.profiles);
+  //------------------handle the editing of household name --------------------
+
   const activeProfile = useAppSelector((state) => state.profile.activeProfile);
   const isOwner = activeProfile?.isOwner;
-  const [isEditing, setIsEditing] = useState(false);
-  const [updatedProfileName, setUpdatedProfilename] = useState(
-    activeProfile?.profileName,
-  );
 
   const [updatedHouseholdName, setUpdatedHouseholdname] = useState(
     activeProfile?.profileName,
   );
 
-  const [editingStates, setEditingStates] = useState(Array(households?.length).fill(false));
-
+  const [editingStates, setEditingStates] = useState(
+    Array(households?.length).fill(false),
+  );
 
   const handleHouseholdSaveClick = async (editHouseholdId: string) => {
     if (editHouseholdId) {
@@ -65,19 +61,17 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
           newHouseholdName: updatedHouseholdName ?? editHouseholdId,
         }),
       );
-         // Update the editing state for the edited household
-         setEditingStates(Array(households?.length).fill(false));
-
+      // Update the editing state for the edited household
+      setEditingStates(Array(households?.length).fill(false));
     }
   };
-  const cancelEditing = (index:number) => {
+  const cancelEditing = (index: number) => {
     const updatedEditingStates = [...editingStates];
     updatedEditingStates[index] = false;
     setEditingStates(updatedEditingStates); // Reset the edited name to the original name
   };
 
-  //-----------------------------------------------------------------------------------
-
+  //-------------------get all the households under activeUser and profiles of the active user in each household------------------------------------------------------
   useEffect(() => {
     const fetchData = async () => {
       try {
@@ -99,7 +93,7 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
     };
 
     fetchData();
-  }, [editingStates]); //runs only onece
+  }, [editingStates]); //after save editing household name, run it again so refresh list
 
   async function GetHouseholdIdsFromActiveUser() {
     const householdsId: string[] = [];
@@ -133,9 +127,8 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
   }
 
   const dispatch = useAppDispatch();
-  //   const activeProfile = useAppSelector((state) => state.profile.activeProfile);
-  const householdSlice = useAppSelector((state) => state.household);
-  const allHouseholds = householdSlice.households;
+//   const householdSlice = useAppSelector((state) => state.household);
+//   const allHouseholds = householdSlice.households;
 
   const handleEnterHousehold = async (household: Household) => {
     dispatch(sethouseholdActive(household));
@@ -149,8 +142,6 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
           householdId: household.id,
         }),
       );
-
-      console.log("aktiva profilen: ");
       // Navigate to the ProfileAccount screen
       navigation.navigate("ProfileAccount", {
         householdId: household.id,
@@ -169,7 +160,7 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
       );
     return currentUserProfilesForAllHouseholds;
   }
-
+//--------------handle themes and the theme buttons------------------
   const { theme, setColorScheme } = useTheme();
   const colorScheme = useColorScheme();
   const [currentTheme, setCurrentTheme] = useState("auto");
@@ -190,7 +181,6 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
     onPanResponderRelease: (e, gestureState) => {
       if (Math.abs(gestureState.dx) > 50) {
         handleToggleTheme();
-        // Do not reset the position here
       }
     },
   });
@@ -200,9 +190,6 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
     outputRange: [-50, 0, 50],
     extrapolate: "clamp",
   });
-
-
- 
 
   return (
     <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
@@ -242,13 +229,12 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
               ]}
               onPress={() => {
                 if (!editingStates[index]) {
-                    handleEnterHousehold(household);
-                  }
+                  handleEnterHousehold(household);
+                }
               }}
             >
-               <View style={{ flexDirection: "row", alignItems: "center" }}>
+              <View style={{ flexDirection: "row", alignItems: "center" }}>
                 {!editingStates[index] && profiles[index] && (
-                 
                   <Image
                     key={0}
                     source={{
@@ -257,9 +243,8 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
                     style={{ height: 20, width: 20 }}
                     alt={`Avatar ${index}`}
                   />
-                 
                 )}
-              </View> 
+              </View>
               {/* <View style={styles.nameContainer}> */}
               <View style={styles.taskItem}>
                 {editingStates[index] ? (
@@ -297,19 +282,13 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
                         updatedEditingStates[index] = !editingStates[index];
                         setEditingStates(updatedEditingStates);
                       }}
-                    //   onPress={() => {
-                    //     setIsEditing(true);
-                    //   }}
                     />
                   </>
                 )}
               </View>
               {editingStates[index] ? (
                 <View>
-                  <Button
-                    mode="elevated"
-                    onPress={() => cancelEditing(index)}
-                  >
+                  <Button mode="elevated" onPress={() => cancelEditing(index)}>
                     Avbryt
                   </Button>
                   <Button

--- a/screens/HouseholdAccountScreen.tsx
+++ b/screens/HouseholdAccountScreen.tsx
@@ -35,6 +35,7 @@ import { Household, Profile } from "../types";
 type HouseholdProps = RootNavigationScreenProps<"HouseholdAccount">;
 
 export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
+    const dispatch = useAppDispatch();
   const activeUser = useAppSelector((state) => state.user.user);
   const [households, setHouseholds] = useState<Household[] | undefined>([]);
   const [profiles, setProfiles] = useState<(Profile[] | undefined)[]>([]);
@@ -126,9 +127,8 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
       });
   }
 
-  const dispatch = useAppDispatch();
-//   const householdSlice = useAppSelector((state) => state.household);
-//   const allHouseholds = householdSlice.households;
+  
+
 
   const handleEnterHousehold = async (household: Household) => {
     dispatch(sethouseholdActive(household));
@@ -225,7 +225,8 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
               key={index}
               style={[
                 theme.cardButton as any,
-                { flexDirection: "row", justifyContent: "space-between" },
+                { alignItems:"flex-start",justifyContent:"space-between",
+             },
               ]}
               onPress={() => {
                 if (!editingStates[index]) {
@@ -233,7 +234,13 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
                 }
               }}
             >
-              <View style={{ flexDirection: "row", alignItems: "center" }}>
+              <View 
+              style={{ 
+                flexDirection: "row", 
+                alignItems: "center",
+                alignContent:"center",
+                }}>
+                <View>
                 {!editingStates[index] && profiles[index] && (
                   <Image
                     key={0}
@@ -245,9 +252,9 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
                   />
                 )}
               </View>
-              {/* <View style={styles.nameContainer}> */}
-              <View style={styles.taskItem}>
+             
                 {editingStates[index] ? (
+                    
                   <TextInput
                     placeholder={household.name}
                     onChangeText={(text) => {
@@ -255,10 +262,20 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
                     }}
                     style={{
                       color: colorScheme === "dark" ? "white" : "black",
+                      borderWidth: 1, 
+                      borderColor: 'lightgray', 
+                      borderRadius: 5,
+                      padding:10 
                     }}
                   />
                 ) : (
-                  <>
+                  <View 
+                  style={{ 
+                    flexDirection: "row", 
+                    alignItems: "center",justifyContent:"space-between",
+                   
+                    }}>
+                
                     <Text
                       style={[
                         styles.profileTitle,
@@ -267,14 +284,17 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
                             colorScheme === "dark"
                               ? "white"
                               : theme.colors.text,
+                              marginLeft:10
                         },
                       ]}
                     >
                       {household.name}
                     </Text>
-
+                    {/* </View> */}
+                    
                     <IconButton
                       icon="pencil"
+                      
                       size={20}
                       onPress={() => {
                         // Toggle the editing state for the clicked household
@@ -283,20 +303,27 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
                         setEditingStates(updatedEditingStates);
                       }}
                     />
-                  </>
+                    
+                  </View>
                 )}
               </View>
               {editingStates[index] ? (
-                <View>
+                <View style={{
+                    flexDirection:"row"
+                    }}>
+                    <View>
                   <Button mode="elevated" onPress={() => cancelEditing(index)}>
                     Avbryt
                   </Button>
+                  </View>
+                  <View>
                   <Button
                     mode="elevated"
                     onPress={() => handleHouseholdSaveClick(household.id)}
                   >
                     Spara
                   </Button>
+                  </View>
                 </View>
               ) : null}
             </TouchableOpacity>

--- a/screens/HouseholdAccountScreen.tsx
+++ b/screens/HouseholdAccountScreen.tsx
@@ -127,9 +127,6 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
       });
   }
 
-  
-
-
   const handleEnterHousehold = async (household: Household) => {
     dispatch(sethouseholdActive(household));
     try {

--- a/screens/HouseholdAccountScreen.tsx
+++ b/screens/HouseholdAccountScreen.tsx
@@ -225,8 +225,7 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
               key={index}
               style={[
                 theme.cardButton as any,
-                { alignItems:"flex-start",justifyContent:"space-between",
-             },
+                {  alignItems:"flex-start", },
               ]}
               onPress={() => {
                 if (!editingStates[index]) {
@@ -240,9 +239,14 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
                 alignItems: "center",
                 alignContent:"center",
                 }}>
-                <View>
+                
                 {!editingStates[index] && profiles[index] && (
-                  <Image
+                  <View   style={{ 
+                    flexDirection: "row", 
+                    alignItems: "center",
+                    justifyContent:"space-between",
+                    }}>
+                    <Image
                     key={0}
                     source={{
                       uri: AvatarUrls[profiles[index]![0].avatar as Avatars],
@@ -250,12 +254,49 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
                     style={{ height: 20, width: 20 }}
                     alt={`Avatar ${index}`}
                   />
+
+                   <Text
+                      style={[
+                        styles.profileTitle,
+                        {
+                          color:
+                            colorScheme === "dark"
+                              ? "white"
+                              : theme.colors.text,
+                              marginLeft:10,
+                              flex:1
+                        },
+                      ]}
+                    >
+                      {household.name}
+                    </Text>
+                    <IconButton
+                      icon="pencil"
+                      
+                      size={20}
+                      onPress={() => {
+                        // Toggle the editing state for the clicked household
+                        const updatedEditingStates = [...editingStates];
+                        updatedEditingStates[index] = !editingStates[index];
+                        setEditingStates(updatedEditingStates);
+                      }}
+                    />
+
+                  </View>
                 )}
               </View>
-             
-                {editingStates[index] ? (
-                    
-                  <TextInput
+
+              {editingStates[index] ? (
+                <View style={{
+                    flexDirection:"row",
+                    alignItems:"center",
+                    justifyContent:"space-between",
+                    flex:1
+                    }}>
+                        <View  style={{
+                    flex:1
+                    }}>
+                        <TextInput
                     placeholder={household.name}
                     onChangeText={(text) => {
                       setUpdatedHouseholdname(text);
@@ -268,49 +309,7 @@ export default function HouseholdAccountScreen({ navigation }: HouseholdProps) {
                       padding:10 
                     }}
                   />
-                ) : (
-                  <View 
-                  style={{ 
-                    flexDirection: "row", 
-                    alignItems: "center",justifyContent:"space-between",
-                   
-                    }}>
-                
-                    <Text
-                      style={[
-                        styles.profileTitle,
-                        {
-                          color:
-                            colorScheme === "dark"
-                              ? "white"
-                              : theme.colors.text,
-                              marginLeft:10
-                        },
-                      ]}
-                    >
-                      {household.name}
-                    </Text>
-                    {/* </View> */}
-                    
-                    <IconButton
-                      icon="pencil"
-                      
-                      size={20}
-                      onPress={() => {
-                        // Toggle the editing state for the clicked household
-                        const updatedEditingStates = [...editingStates];
-                        updatedEditingStates[index] = !editingStates[index];
-                        setEditingStates(updatedEditingStates);
-                      }}
-                    />
-                    
-                  </View>
-                )}
-              </View>
-              {editingStates[index] ? (
-                <View style={{
-                    flexDirection:"row"
-                    }}>
+                        </View>
                     <View>
                   <Button mode="elevated" onPress={() => cancelEditing(index)}>
                     Avbryt


### PR DESCRIPTION
1. moved edit house name function to householdAccount from ProfileScreen
2. change the avatars so that in frond of each house,  it is renders the avatar of the activeUser in that house
3. styles the screen and edited(only the one that is clicked is going to change to edit form the rest remain the same)
4. rerender the household list after editing the name, so the list is refreshed