### PR TITLE
336 if no data is present in stat show grayscales

### DIFF
--- a/data/emptyPieCharts.ts
+++ b/data/emptyPieCharts.ts
@@ -1,0 +1,34 @@
+export const emptyPieChartsData = [
+  {
+    colors: ["#b7b6b6", "#a09f9e", "#8b8a89"],
+    series: [10, 10, 10],
+    title: "Diska",
+  },
+  {
+    colors: ["#b7b6b6", "#a09f9e", "#8b8a89"],
+    series: [10, 5, 8],
+    title: "Laga mat",
+  },
+  {
+    colors: ["#b7b6b6", "#a09f9e", "#8b8a89"],
+    series: [4, 6, 2],
+    title: "Dammsuga",
+  },
+  {
+    colors: ["#b7b6b6", "#a09f9e", "#8b8a89"],
+    series: [2, 2, 4],
+    title: "Mata fisken",
+  },
+  {
+    colors: ["#b7b6b6", "#a09f9e", "#8b8a89"],
+    series: [10, 10, 10],
+    title: "Tvätta",
+  },
+];
+
+export const emptySumPieChart = [
+  {
+    colors: ["#b7b6b6", "#a09f9e", "#8b8a89"],
+    series: [36, 33, 34],
+  },
+];

--- a/data/emptyPieCharts.ts
+++ b/data/emptyPieCharts.ts
@@ -1,4 +1,6 @@
-export const emptyPieChartsData = [
+import { StatData } from "../types";
+
+export const emptyPieChartsData: StatData[] = [
   {
     colors: ["#b7b6b6", "#a09f9e", "#8b8a89"],
     series: [10, 10, 10],
@@ -26,9 +28,6 @@ export const emptyPieChartsData = [
   },
 ];
 
-export const emptySumPieChart = [
-  {
-    colors: ["#b7b6b6", "#a09f9e", "#8b8a89"],
-    series: [36, 33, 34],
-  },
-];
+export const emptySumPieChartSeries = [36, 33, 34];
+
+export const emptySumPieChartColors = ["#b7b6b6", "#a09f9e", "#8b8a89"];

--- a/data/theme.ts
+++ b/data/theme.ts
@@ -49,6 +49,13 @@ export type Theme = typeof DarkTheme & {
     justifyContent: string;
     alignItems: string;
   };
+  taskTitle: {
+    color: string;
+    width: number;
+    textAlign: string;
+    padding: number;
+    fontWeight: string;
+  };
   // forgotPasswordButtonText: {
 
   //   color: string,
@@ -119,6 +126,13 @@ export const AppLightTheme: Theme = {
     justifyContent: "space-between",
     alignItems: "center",
   },
+  taskTitle: {
+    color: "black",
+    width: 110,
+    textAlign: "center",
+    padding: 2,
+    fontWeight: "bold",
+  },
 };
 
 export const AppDarkTheme: Theme = {
@@ -184,4 +198,11 @@ export const AppDarkTheme: Theme = {
   //   color: "white",
   //   fontSize: 10,
   // },
+  taskTitle: {
+    color: "white",
+    width: 110,
+    textAlign: "center",
+    padding: 2,
+    fontWeight: "bold",
+  },
 };

--- a/navigators/TopTabNavigator.tsx
+++ b/navigators/TopTabNavigator.tsx
@@ -40,6 +40,7 @@ export default function TopTabNavigator() {
     endOfLastMonth,
     completions,
   );
+  console.log("LAST MONTH: ", lastMonth);
 
   useEffect(() => {
     if (lastWeek) {
@@ -69,22 +70,32 @@ export default function TopTabNavigator() {
           tabBarLabel: "Denna Vecka",
         })}
       />
-      <TopTab.Screen
-        name={"StatisticsLastWeek"}
-        component={StatisticScreen}
-        initialParams={{ startDate: startOfLastWeek, endDate: endOfLastWeek }}
-        options={() => ({
-          tabBarLabel: "Förra Vecka",
-        })}
-      />
-      <TopTab.Screen
-        name={"LastMonth"}
-        component={StatisticScreen}
-        initialParams={{ startDate: startOfLastMonth, endDate: endOfLastMonth }}
-        options={() => ({
-          tabBarLabel: "Förra månaden",
-        })}
-      />
+      {lastWeek.length > 0 && (
+        <TopTab.Screen
+          name={"StatisticsLastWeek"}
+          component={StatisticScreen}
+          initialParams={{
+            startDate: startOfLastWeek,
+            endDate: endOfLastWeek,
+          }}
+          options={() => ({
+            tabBarLabel: "Förra Vecka",
+          })}
+        />
+      )}
+      {lastMonth.length > 0 && (
+        <TopTab.Screen
+          name={"LastMonth"}
+          component={StatisticScreen}
+          initialParams={{
+            startDate: startOfLastMonth,
+            endDate: endOfLastMonth,
+          }}
+          options={() => ({
+            tabBarLabel: "Förra månaden",
+          })}
+        />
+      )}
     </TopTab.Navigator>
   );
 }

--- a/screens/StatisticScreen.tsx
+++ b/screens/StatisticScreen.tsx
@@ -1,21 +1,21 @@
-import React, { useCallback, useState } from "react";
-import { ScrollView, StyleSheet, Text, View, Image } from "react-native";
-import PiechartComponent from "../components/PiechartComponent";
-import { useAppSelector } from "../store/store";
-import { StatData } from "../types";
-import { useTheme } from "../contexts/themeContext";
-import {
-  SummerizeEachTask,
-  summarizeDataByColor,
-} from "../utils/statisticHandler";
 import { useFocusEffect } from "@react-navigation/native";
+import React, { useCallback, useState } from "react";
+import { Image, ScrollView, StyleSheet, Text, View } from "react-native";
+import PiechartComponent from "../components/PiechartComponent";
+import { useTheme } from "../contexts/themeContext";
 import { AvatarUrls, Avatars, getAvatarColorString } from "../data/avatars";
-import { TopTabScreenProps } from "../navigators/navigationTypes";
 import {
   emptyPieChartsData,
   emptySumPieChartColors,
   emptySumPieChartSeries,
 } from "../data/emptyPieCharts";
+import { TopTabScreenProps } from "../navigators/navigationTypes";
+import { useAppSelector } from "../store/store";
+import { StatData } from "../types";
+import {
+  SummerizeEachTask,
+  summarizeDataByColor,
+} from "../utils/statisticHandler";
 
 type StatProps =
   | TopTabScreenProps<"StatisticsCurrentWeek">
@@ -46,6 +46,7 @@ export default function StatisticScreen({ route }: StatProps) {
   const [statsForTasks, setStatsForTasks] = useState<StatData[]>([]);
   const [totalSumColors, setTotalSumColors] = useState<string[]>([]);
   const [totalSumSeries, setTotalSumSeries] = useState<number[]>([]);
+  const [isData, setIsData] = useState<StatData[]>([]);
 
   const handleFocusEffect = useCallback(() => {
     console.log("USE-EFFECT STATS: ", completions);
@@ -58,6 +59,14 @@ export default function StatisticScreen({ route }: StatProps) {
       endDate,
     );
     setStatsForTasks(summarizedData);
+    console.log("SUMMARIZEDDATA: ", summarizedData);
+
+    if (summarizedData.length === 0) {
+      setIsData(greyDataSum);
+    } else {
+      setIsData(statsForTasks);
+    }
+
     const data = summarizeDataByColor(summarizedData);
     setTotalSumColors(data.colors);
     setTotalSumSeries(data.series);
@@ -67,10 +76,7 @@ export default function StatisticScreen({ route }: StatProps) {
   }, [completions, tasks, profiles, startDate, endDate]);
 
   useFocusEffect(handleFocusEffect);
-  const chunkedCharts = arrayChunk(
-    statsForTasks ? statsForTasks : greyDataSum,
-    3,
-  );
+  const chunkedCharts = arrayChunk(isData, 3);
 
   return (
     <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
@@ -135,7 +141,7 @@ export default function StatisticScreen({ route }: StatProps) {
                   </Text>
                   {chart.colors.length > 0 && chart.series.length > 0 && (
                     <PiechartComponent
-                      widthAndHeight={110}
+                      widthAndHeight={100}
                       series={chart.series}
                       sliceColor={chart.colors}
                     />
@@ -153,7 +159,7 @@ export default function StatisticScreen({ route }: StatProps) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    padding: 12,
+    paddingTop: 20,
   },
   row: {
     flexDirection: "row",

--- a/screens/StatisticScreen.tsx
+++ b/screens/StatisticScreen.tsx
@@ -68,7 +68,7 @@ export default function StatisticScreen({ route }: StatProps) {
 
   useFocusEffect(handleFocusEffect);
   const chunkedCharts = arrayChunk(
-    statsForTasks ? greyDataSum : statsForTasks,
+    statsForTasks ? statsForTasks : greyDataSum,
     3,
   );
 

--- a/screens/StatisticScreen.tsx
+++ b/screens/StatisticScreen.tsx
@@ -119,7 +119,7 @@ export default function StatisticScreen({ route }: StatProps) {
             <View style={styles.row} key={rowIndex}>
               {row.map((chart, columnIndex) => (
                 <View style={styles.piechartContainer} key={columnIndex}>
-                  <Text style={styles.taskTitle} numberOfLines={2}>
+                  <Text style={theme.taskTitle as any} numberOfLines={2}>
                     {chart.title}
                   </Text>
                   {chart.colors.length > 0 && chart.series.length > 0 ? (
@@ -157,12 +157,6 @@ const styles = StyleSheet.create({
     flexDirection: "column",
     justifyContent: "center",
     padding: 10,
-  },
-  taskTitle: {
-    width: 110,
-    textAlign: "center",
-    padding: 2,
-    fontWeight: "bold",
   },
   topChart: {
     alignItems: "center",

--- a/screens/StatisticScreen.tsx
+++ b/screens/StatisticScreen.tsx
@@ -11,6 +11,11 @@ import {
 import { useFocusEffect } from "@react-navigation/native";
 import { AvatarUrls, Avatars, getAvatarColorString } from "../data/avatars";
 import { TopTabScreenProps } from "../navigators/navigationTypes";
+import {
+  emptyPieChartsData,
+  emptySumPieChartColors,
+  emptySumPieChartSeries,
+} from "../data/emptyPieCharts";
 
 type StatProps =
   | TopTabScreenProps<"StatisticsCurrentWeek">
@@ -34,6 +39,9 @@ export default function StatisticScreen({ route }: StatProps) {
   const completions = useAppSelector(
     (state) => state.taskCompletion.completions,
   );
+  const greyDataSumSeries = emptySumPieChartSeries;
+  const greyDataSumColors = emptySumPieChartColors;
+  const greyDataSum = emptyPieChartsData;
   const profileSlice = useAppSelector((state) => state.profile.profiles);
   const [statsForTasks, setStatsForTasks] = useState<StatData[]>([]);
   const [totalSumColors, setTotalSumColors] = useState<string[]>([]);
@@ -59,7 +67,10 @@ export default function StatisticScreen({ route }: StatProps) {
   }, [completions, tasks, profiles, startDate, endDate]);
 
   useFocusEffect(handleFocusEffect);
-  const chunkedCharts = arrayChunk(statsForTasks, 3);
+  const chunkedCharts = arrayChunk(
+    statsForTasks ? greyDataSum : statsForTasks,
+    3,
+  );
 
   return (
     <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
@@ -76,8 +87,8 @@ export default function StatisticScreen({ route }: StatProps) {
           <View style={styles.topChart}>
             <PiechartComponent
               widthAndHeight={250}
-              series={[100]}
-              sliceColor={["gray"]}
+              series={greyDataSumSeries}
+              sliceColor={greyDataSumColors}
             />
           </View>
         )}
@@ -122,17 +133,11 @@ export default function StatisticScreen({ route }: StatProps) {
                   <Text style={theme.taskTitle as any} numberOfLines={2}>
                     {chart.title}
                   </Text>
-                  {chart.colors.length > 0 && chart.series.length > 0 ? (
+                  {chart.colors.length > 0 && chart.series.length > 0 && (
                     <PiechartComponent
                       widthAndHeight={110}
                       series={chart.series}
                       sliceColor={chart.colors}
-                    />
-                  ) : (
-                    <PiechartComponent
-                      widthAndHeight={110}
-                      series={[100]}
-                      sliceColor={["gray"]}
                     />
                   )}
                 </View>


### PR DESCRIPTION
![image](https://github.com/Radagastno1/Household/assets/112871777/33195177-3077-4262-b769-0c75f2238638)
No more clipping of the side of piecharts on iphoneX. Yes MY phone! :)

Show of gray circle if theres no data:
![image](https://github.com/Radagastno1/Household/assets/112871777/d1347736-898e-4c7c-85f5-c6c83e68922a)

![image](https://github.com/Radagastno1/Household/assets/112871777/4b8e85d2-f846-48cc-beae-ef45d0026066)

💯 OBS! OBS! OBS! There is a minor bug where the smaller piecharts arent rendering as they should. This needs to be sorted out! I'll put a issue on that! 💯  